### PR TITLE
Non-GUI three-line overlay

### DIFF
--- a/bupper.el
+++ b/bupper.el
@@ -28,17 +28,39 @@
 
 ;;; Code:
 
+(defface bupper-face
+;; '((:height 160)
+;;   (:weight ultra-bold)
+;;   (:foreground "red")
+;;   (:background "white")
+;;   (:box "red")))
+;; See also documentation for `defface' "type" for specifying `window-system'.
+  '((((class grayscale)
+      (background light)) (:background "DimGray"))
+    (((class grayscale)
+      (background dark))  (:background "LightGray"))
+    (((class color)
+      (background light)) (:foreground "White" :background "DarkOrange1"))
+    (((class color)
+      (background dark))  (:foreground "Black" :background "DarkOrange1")))
+  "Face used to highlight bupper window ID numbers."
+  :group 'cursor-flash)
+
 (defun bupper--add-string-overlay-to-window (window string)
   "Add the STRING `string` as overlay in `WINDOW` in the first visible position."
   (with-current-buffer (window-buffer window)
-    (let ((ov (make-overlay (window-start window)
-                            (+ 1 (window-start window)))))
-      (overlay-put ov 'face '((:height 160)
-                              (:weight ultra-bold)
-                              (:foreground "red")
-                              (:background "white")
-                              (:box "red")))
-      (overlay-put ov 'display string))))
+    (setq string (concat " " string " "))
+    (save-mark-and-excursion
+      (let ((pos (window-start window))
+            end-col ov)
+        (dotimes (x 3)
+          (goto-char pos)
+          (when (> 2 (setq end-col (progn (end-of-line) (current-column))))
+            (insert "   "))
+          (setq ov (make-overlay pos (+ 3 (goto-char pos))))
+          (overlay-put ov 'face 'bupper-face)
+          (overlay-put ov 'display (if (= x 1) string "   "))
+          (setq pos (1+ (line-end-position))))))))
 
 (defun bupper--remove-overlays-from-window (window)
   "Remove all overlays from `WINDOW."

--- a/bupper.el
+++ b/bupper.el
@@ -28,17 +28,39 @@
 
 ;;; Code:
 
+(defface bupper-face
+;; '((:height 160)
+;;   (:weight ultra-bold)
+;;   (:foreground "red")
+;;   (:background "white")
+;;   (:box "red")))
+;; See also documentation for `defface' "type" for specifying `window-system'.
+  '((((class grayscale)
+      (background light)) (:background "DimGray"))
+    (((class grayscale)
+      (background dark))  (:background "LightGray"))
+    (((class color)
+      (background light)) (:foreground "White" :background "DarkOrange1"))
+    (((class color)
+      (background dark))  (:foreground "Black" :background "DarkOrange1")))
+  "Face used to highlight bupper window ID numbers."
+  :group 'cursor-flash)
+
 (defun bupper--add-string-overlay-to-window (window string)
   "Add the STRING `string` as overlay in `WINDOW` in the first visible position."
   (with-current-buffer (window-buffer window)
-    (let ((ov (make-overlay (window-start window)
-                            (+ 1 (window-start window)))))
-      (overlay-put ov 'face '((:height 160)
-                              (:weight ultra-bold)
-                              (:foreground "red")
-                              (:background "white")
-                              (:box "red")))
-      (overlay-put ov 'display string))))
+    (setq string (concat " " string " "))
+    (save-mark-and-excursion
+      (let ((pos (window-start window))
+            ov)
+        (dotimes (x 3)
+          (goto-char pos)
+          (when (> 2 (progn (end-of-line) (current-column)))
+            (insert "   "))
+          (setq ov (make-overlay pos (+ 3 (goto-char pos))))
+          (overlay-put ov 'face 'bupper-face)
+          (overlay-put ov 'display (if (= x 1) string "   "))
+          (setq pos (1+ (line-end-position))))))))
 
 (defun bupper--remove-overlays-from-window (window)
   "Remove all overlays from `WINDOW."


### PR DESCRIPTION
+ Define the overlay face as a defface symbol, so users can easily
  configure it to their wishes.

  + The example provided demonstrates a face that is flexible for
    color and non-color displays, and for dark or light backgrounds.
    It is also possible to support flexibility for tty or different
    forms of GUI displays (see documentation for `defface' "type" for
    specifying `window-system').

+ Mark each window with a three-line nine-space highlighted overlay
  instead of a single character one.

  + This is much more visible and readable on non-GUI frames.

+ Care is taken for the overlay to display properly even if the a row
  of the buffer is less than three columns wide.